### PR TITLE
Automate Flutter Package Creation and Add Core Package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY:default activate-tools clean
+.PHONY:default activate-tools clean create-package
 
 default:
 	melos bs
@@ -10,3 +10,7 @@ activate-tools:
 clean:
 	melos clean
 	melos bs
+
+create-package:
+	chmod +x scripts/create-flutter-package.sh
+	@scripts/create-flutter-package.sh $(name) $(folder)

--- a/common/core/.metadata
+++ b/common/core/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "35c388afb57ef061d06a39b537336c87e0e3d1b1"
+  channel: "stable"
+
+project_type: package

--- a/common/core/lib/core.dart
+++ b/common/core/lib/core.dart
@@ -1,0 +1,1 @@
+library;

--- a/common/core/pubspec.yaml
+++ b/common/core/pubspec.yaml
@@ -1,0 +1,20 @@
+name: core
+description: Flutter developer coding challenge core package.
+version: 0.0.1
+publish_to: "none"
+
+environment:
+  sdk: ">=3.4.4 <4.0.0"
+  flutter: ">=3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_lints: ^4.0.0
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/scripts/create-flutter-package.sh
+++ b/scripts/create-flutter-package.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+if [ -z "$name" ]; then
+  echo "Error: You should provide the "name" argument"
+  exit 1
+fi
+
+if [ -z "$folder" ]; then
+  echo "Error: You should provide the "folder" argument"
+  exit 1
+fi
+
+if [ ! -z "$folder" ]; then
+  if [ ! -d "$folder" ]; then
+    mkdir -p "$folder"
+  fi
+  cd $folder
+fi
+
+flutter create --template=package $1
+cd $name && rm -rf LICENSE CHANGELOG.md README.md analysis_options.yaml pubspec.yaml .gitignore lib/$name.dart test/ linux macos windows android ios
+
+touch lib/$name.dart
+echo "library;" >lib/$name.dart
+
+touch pubspec.yaml
+echo "name: $name
+description: Flutter developer coding challenge $name package.
+version: 0.0.1
+publish_to: \"none\"
+
+environment:
+  sdk: \">=3.4.4 <4.0.0\"
+  flutter: \">=3.0.0\"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_lints: ^4.0.0
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true" >pubspec.yaml
+
+dart format .
+flutter pub get
+
+if [ $? -eq 0 ]; then
+  echo "Package $name created :)"
+else
+  echo "Error to create $name package"
+fi


### PR DESCRIPTION
This PR introduces a shell script to automate Flutter package creation and updates the Makefile to include a `create-package` command. Additionally, the `core` package was generated using this automation.

## Changes
- Added `scripts/create-flutter-package.sh` to automate Flutter package creation.
- Updated `Makefile` with the `create-package` command.
- Generated `core` package using the automation.

## How to Apply
1. To create a new package, run: `make create-package name=package_name folder=package_folder`

## TODO
- Add support for **Windows**, since Makefile and shell scripts are not natively supported. A PowerShell alternative (.ps1) could be implemented.

## Open for Feedback and Suggestions
If you have any issues or suggestions, feel free to let me know! I'm happy to help and open to discussing alternative approaches. Looking forward to your comments on this PR! 🚀