### PR TITLE
Implement Internationalization (`i18n`)

### DIFF
--- a/app/lib/l10n/main_l10n.dart
+++ b/app/lib/l10n/main_l10n.dart
@@ -1,0 +1,10 @@
+import 'package:i18n/i18n.dart';
+
+class MainL10n extends I18NextL10n {
+  MainL10n.of(super.context)
+      : super(
+          namespace: 'main',
+        );
+
+  String get title => localize('title');
+}

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -2,16 +2,29 @@ import 'dart:convert';
 
 import 'package:core/core.dart';
 import 'package:flutter/material.dart';
+import 'package:i18n/i18n.dart';
+import 'package:i18n/i18next.dart';
 
 import 'app_service_locator.dart';
+import 'l10n/main_l10n.dart';
 import 'models/restaurant.dart';
 import 'query.dart';
 
 const _baseUrl = 'https://api.yelp.com/v3/graphql';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
   await initAppDependencies();
-  runApp(const RestaurantTour());
+  runApp(
+    I18nProvider.fromAssetBundle(
+      i18nextOptions: I18NextOptions(
+        formats: formatters,
+        missingInterpolationHandler: interpolationFallback,
+      ),
+      child: const RestaurantTour(),
+    ),
+  );
 }
 
 class RestaurantTour extends StatelessWidget {
@@ -19,9 +32,12 @@ class RestaurantTour extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    final i18n = I18nProvider.of(context);
+    return MaterialApp(
       title: 'Restaurant Tour',
-      home: HomePage(),
+      supportedLocales: i18n.supportedLocales,
+      localizationsDelegates: i18n.localizationsDelegates,
+      home: const HomePage(),
     );
   }
 }
@@ -57,12 +73,13 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = MainL10n.of(context);
     return Scaffold(
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Text('Restaurant Tour'),
+            Text(l10n.title),
             ElevatedButton(
               child: const Text('Fetch Restaurants'),
               onPressed: () async {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -253,6 +253,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -314,6 +319,29 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  i18n:
+    dependency: "direct main"
+    description:
+      path: "../common/i18n"
+      relative: true
+    source: path
+    version: "0.0.1"
+  i18next:
+    dependency: transitive
+    description:
+      name: i18next
+      sha256: "4a2eb141fa5e20aad966ac29b4dad2293ab150f98ac3f70c69da986f426e669f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.3"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -418,6 +446,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
@@ -442,6 +478,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.2"
   pub_semver:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -13,13 +13,14 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.2.2
+  i18n: ^0.0.1
   json_annotation: ^4.9.0
 
 dev_dependencies:
+  build_runner: ^2.4.10
+  flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
-  build_runner: ^2.4.10
   json_serializable: ^6.8.0
 
 flutter:

--- a/common/i18n/.metadata
+++ b/common/i18n/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "b0850beeb25f6d5b10426284f506557f66181b36"
+  channel: "stable"
+
+project_type: package

--- a/common/i18n/lib/i18n.dart
+++ b/common/i18n/lib/i18n.dart
@@ -1,0 +1,1 @@
+library;

--- a/common/i18n/lib/i18n.dart
+++ b/common/i18n/lib/i18n.dart
@@ -1,1 +1,5 @@
 library;
+
+export 'src/i18n.dart';
+export 'src/interpolation_formatter.dart';
+export 'src/l10n.dart';

--- a/common/i18n/lib/i18next.dart
+++ b/common/i18n/lib/i18next.dart
@@ -1,0 +1,3 @@
+library i18next;
+
+export 'package:i18next/i18next.dart';

--- a/common/i18n/lib/l10n/en-US.json
+++ b/common/i18n/lib/l10n/en-US.json
@@ -1,0 +1,5 @@
+{
+    "main": {
+        "title": "Restaurant Tour"
+    }
+}

--- a/common/i18n/lib/l10n/pt-BR.json
+++ b/common/i18n/lib/l10n/pt-BR.json
@@ -1,0 +1,5 @@
+{
+    "main": {
+        "title": "Tour de Restaurantes"
+    }
+}

--- a/common/i18n/lib/src/i18n.dart
+++ b/common/i18n/lib/src/i18n.dart
@@ -1,0 +1,86 @@
+import 'dart:developer';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:i18next/i18next.dart';
+import 'package:provider/provider.dart';
+
+import 'single_file_asset_bundle_data_source.dart';
+
+const List<Locale> kSupportedLocales = <Locale>[
+  Locale('pt', 'BR'),
+  Locale('en', 'US'),
+];
+
+class I18n extends ChangeNotifier {
+  I18n({
+    Locale? locale,
+    required List<Locale> supportedLocales,
+    required List<LocalizationsDelegate> localizationsDelegates,
+  })  : _locale = locale ?? supportedLocales.first,
+        supportedLocales = List.unmodifiable(supportedLocales),
+        localizationsDelegates = List.unmodifiable(localizationsDelegates) {
+    _log('Initializing locale with $_locale');
+  }
+
+  final Locale _locale;
+  final List<Locale> supportedLocales;
+  final List<LocalizationsDelegate> localizationsDelegates;
+
+  Locale get locale => _locale;
+
+  void _log(String message, [Object? error, StackTrace? stackTrace]) {
+    log(message, error: error, stackTrace: stackTrace, name: 'I18n');
+  }
+}
+
+class I18nProvider extends ChangeNotifierProvider<I18n> {
+  I18nProvider({
+    super.key,
+    Locale? locale,
+    List<Locale> supportedLocales = kSupportedLocales,
+    required LocalizationDataSource localizationDataSource,
+    I18NextOptions? i18nextOptions,
+    super.lazy,
+    super.builder,
+    super.child,
+  }) : super(
+          create: (context) => I18n(
+            locale: locale,
+            supportedLocales: supportedLocales,
+            localizationsDelegates: [
+              ...GlobalMaterialLocalizations.delegates,
+              I18NextLocalizationDelegate(
+                locales: supportedLocales,
+                dataSource: localizationDataSource,
+                options: i18nextOptions,
+              ),
+            ],
+          ),
+        );
+
+  I18nProvider.fromAssetBundle({
+    Key? key,
+    List<Locale> supportedLocales = kSupportedLocales,
+    Locale? locale,
+    String assetPath = 'packages/i18n/lib/l10n/<locale_name>.json',
+    I18NextOptions? i18nextOptions,
+    bool? lazy,
+    TransitionBuilder? builder,
+    Widget? child,
+  }) : this(
+          key: key,
+          supportedLocales: supportedLocales,
+          locale: locale,
+          localizationDataSource: SingleAssetBundleLocalizationDataSource(
+            assetPath: assetPath,
+          ),
+          i18nextOptions: i18nextOptions,
+          lazy: lazy,
+          builder: builder,
+          child: child,
+        );
+
+  static I18n of(BuildContext context, {bool listen = true}) =>
+      Provider.of<I18n>(context, listen: listen);
+}

--- a/common/i18n/lib/src/interpolation_formatter.dart
+++ b/common/i18n/lib/src/interpolation_formatter.dart
@@ -1,0 +1,48 @@
+import 'dart:ui';
+
+import 'package:i18next/i18next.dart';
+import 'package:intl/intl.dart';
+
+/// Gets all the default formatters for the i18next machine
+Map<String, ValueFormatter> get formatters => {
+      'uppercase': _toUpperCase,
+      'lowercase': _toLowerCase,
+      'sentence': _toSentenceCase,
+    };
+
+Object? interpolationFallback(
+  Object? value,
+  InterpolationFormat format,
+  Locale locale,
+  I18NextOptions options,
+) {
+  if (value is num) {
+    return value.toString();
+  }
+
+  return value;
+}
+
+String? _toUpperCase(
+  Object? value,
+  InterpolationFormat format,
+  Locale locale,
+  I18NextOptions options,
+) =>
+    value?.toString().toUpperCase();
+
+String? _toLowerCase(
+  Object? value,
+  InterpolationFormat format,
+  Locale locale,
+  I18NextOptions options,
+) =>
+    value?.toString().toLowerCase();
+
+String? _toSentenceCase(
+  Object? value,
+  InterpolationFormat format,
+  Locale locale,
+  I18NextOptions options,
+) =>
+    toBeginningOfSentenceCase(value?.toString());

--- a/common/i18n/lib/src/l10n.dart
+++ b/common/i18n/lib/src/l10n.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/widgets.dart';
+import 'package:i18next/i18next.dart';
+
+import 'utils.dart';
+
+typedef LocalizeFallback = String Function(String key);
+
+/// A convenient localization base class for adding an access layer of
+/// properties or methods, rather than relying only on String keys.
+///
+/// See also [CommonL10n] for the most common localizations.
+/// And [I18NextL10n] for the base localization mechanism.
+abstract class L10n {
+  const L10n({this.arguments});
+
+  /// Optional default arguments added for every [localize] and
+  /// [localizeOptional] operations.
+  final Map<String, dynamic>? arguments;
+
+  String localize(
+    String key, {
+    int? count,
+    String? context,
+    Map<String, dynamic>? arguments,
+    LocalizeFallback? orElse,
+  });
+
+  String? localizeOptional(
+    String key, {
+    int? count,
+    String? context,
+    Map<String, dynamic>? arguments,
+  });
+}
+
+class I18NextL10n extends L10n {
+  I18NextL10n(
+    BuildContext context, {
+    required this.namespace,
+    this.keyPrefix,
+    super.arguments,
+  }) : // for this l10n to work, I18Next instance must exist at runtime
+        _i18next = I18Next.of(context)!;
+
+  final I18Next _i18next;
+  final String? namespace;
+  final String? keyPrefix;
+
+  @override
+  String localize(
+    String key, {
+    int? count,
+    String? context,
+    Map<String, dynamic>? arguments,
+    LocalizeFallback? orElse,
+  }) {
+    return _i18next.t(
+      _adjustKey(key),
+      count: count,
+      context: context,
+      variables: mergeArguments(this.arguments, arguments),
+      orElse: orElse,
+    );
+  }
+
+  @override
+  String? localizeOptional(
+    String key, {
+    int? count,
+    String? context,
+    Map<String, dynamic>? arguments,
+  }) {
+    return _i18next.tOrNull(
+      _adjustKey(key),
+      count: count,
+      context: context,
+      variables: mergeArguments(this.arguments, arguments),
+    );
+  }
+
+  String _adjustKey(String key) {
+    var newKey = key;
+    if (keyPrefix != null) {
+      final keySeparator = _i18next.options.keySeparator ?? '.';
+      newKey = '$keyPrefix$keySeparator$newKey';
+    }
+    if (namespace != null) {
+      final nsSeparator = _i18next.options.namespaceSeparator ?? ':';
+      newKey = '$namespace$nsSeparator$newKey';
+    }
+    return newKey;
+  }
+}

--- a/common/i18n/lib/src/single_file_asset_bundle_data_source.dart
+++ b/common/i18n/lib/src/single_file_asset_bundle_data_source.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+import 'dart:ui';
+
+import 'package:flutter/services.dart';
+import 'package:i18next/i18next.dart';
+
+/// Retrieves a single asset that contains all the localizations for a single
+/// locale.
+class SingleAssetBundleLocalizationDataSource
+    implements LocalizationDataSource {
+  SingleAssetBundleLocalizationDataSource({
+    required this.assetPath,
+    AssetBundle? bundle,
+    this.cache = true,
+  })  : bundle = bundle ?? rootBundle,
+        super();
+
+  /// The asset path that is defined on the pubspec.
+  ///
+  /// This string needs one point of substitution for [Locale]
+  /// 'assets/<locale_name>.json' will be interpolated as
+  /// 'assets/pt-BR.json'.
+  final String assetPath;
+
+  /// The [AssetBundle] where it retrieves the assets from.
+  ///
+  /// Defaults no [rootBundle].
+  final AssetBundle bundle;
+
+  final bool cache;
+
+  /// The end result is a [Map] that contains all the namespaces.
+  @override
+  Future<Map<String, dynamic>> load(Locale locale) async {
+    final assetKey =
+        assetPath.replaceFirst('<locale_name>', locale.toLanguageTag());
+    final assetContents = await bundle
+        .loadString(assetKey, cache: cache)
+        .then<Map<String, dynamic>>((string) => json.decode(string));
+    return assetContents;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AssetBundleLocalizationDataSource &&
+          runtimeType == other.runtimeType &&
+          cache == other.cache &&
+          bundle == other.bundle;
+
+  @override
+  int get hashCode => Object.hash(
+        bundle,
+        cache,
+      );
+}

--- a/common/i18n/lib/src/utils.dart
+++ b/common/i18n/lib/src/utils.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:collection/collection.dart';
+import 'package:intl/locale.dart' as locale;
+
+/// Based on the system's locale, determines the most appropriate [Locale]
+/// from [supportedLocales].
+/// Returns null if no appropriate locale was found.
+Locale? determineLocale(List<Locale> supportedLocales) {
+  final currentLocale = Platform.localeName;
+  final parsed = tryParseLocale(currentLocale);
+  return parsed != null ? findSupportedLocale(parsed, supportedLocales) : null;
+}
+
+/// Attempts to parse [identifier] into a [Locale].
+/// Returns null if it fails or if it is mal-formed.
+Locale? tryParseLocale(String identifier) {
+  final parsed = locale.Locale.tryParse(identifier);
+  return parsed != null
+      ? Locale(parsed.languageCode, parsed.countryCode)
+      : null;
+}
+
+/// Attempts to find a matching [Locale] in [supportedLocales].
+/// Returns null if no appropriate locale was found.
+///
+/// The [supportedLocales] order matters when determining the fallback when
+/// an exact match can't be found. (first is preferred)
+Locale? findSupportedLocale(
+  Locale locale,
+  List<Locale> supportedLocales,
+) {
+  return supportedLocales.firstWhereOrNull((e) => e == locale) ??
+      supportedLocales.firstWhereOrNull(
+        (e) => e.languageCode == locale.languageCode,
+      );
+}
+
+/// Merges two [Map]s such that:
+/// (null, null) = null
+/// (some(a), null) = some(a)
+/// (null, some(b)) = some(b)
+/// (some(a), some(b)) = some(a+b)
+Map<String, dynamic>? mergeArguments(
+  Map<String, dynamic>? baseArguments,
+  Map<String, dynamic>? newArguments,
+) {
+  if (newArguments == null) return baseArguments;
+  if (baseArguments == null) return newArguments;
+  return {...baseArguments, ...newArguments};
+}

--- a/common/i18n/pubspec.yaml
+++ b/common/i18n/pubspec.yaml
@@ -1,0 +1,20 @@
+name: i18n
+description: Flutter developer coding challenge i18n package.
+version: 0.0.1
+publish_to: "none"
+
+environment:
+  sdk: ">=3.4.4 <4.0.0"
+  flutter: ">=3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_lints: ^4.0.0
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/common/i18n/pubspec.yaml
+++ b/common/i18n/pubspec.yaml
@@ -8,8 +8,14 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
+  collection: ^1.18.0
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  i18next: ^0.7.3
+  intl: ^0.19.0
+  provider: ^6.1.2
 
 dev_dependencies:
   flutter_lints: ^4.0.0
@@ -17,4 +23,9 @@ dev_dependencies:
     sdk: flutter
 
 flutter:
-  uses-material-design: true
+  assets:
+    # These are the localization assets, flutter can't infer wildcards here due to
+    # how it handles asset resolutions (1x, 2x, 3x, ...), so we have to add the
+    # latest dir before the files.
+    - lib/l10n/pt-BR.json
+    - lib/l10n/en-US.json


### PR DESCRIPTION
This PR introduces internationalization support (`i18n`) for the app, enabling localization for multiple languages. Additionally, a temporary test was added in `main.dart` to manually verify language switching in the emulator.

## Changes
- Created `i18n` package to handle localization.  
- Implemented internationalization using `i18next`.  
- Configured supported locales (`pt-BR`, `en-US`).  
- Added a manual test in `main.dart` to verify language switching.

## How to Apply 
1. Run: `make` to fetch new dependencies.
2. Run the app on an emulator or device.
3. Change the system language to test localization behavior.

## Tests
| Language: English 🇺🇸 | Language: Portuguese 🇧🇷 |  
|----------------------|----------------------|  
| ![English Test](https://github.com/user-attachments/assets/6511cc31-c5a1-4efa-adbf-4fe01a558384) | ![Portuguese Test](https://github.com/user-attachments/assets/89ae5496-667c-4a26-bbfb-6d12823c6e2a) |  

## Open for Feedback and Suggestions
If you have any issues or suggestions, feel free to let me know! I'm happy to help and open to discussing alternative approaches. Looking forward to your comments on this PR! 🚀